### PR TITLE
Update Redis check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Use "ping" instead of "set"/"get" in Redis check.
 
 ## [0.1.3] - 2021-09-28
 ### Added

--- a/src/Checks/Redis.php
+++ b/src/Checks/Redis.php
@@ -5,7 +5,6 @@ namespace Butler\Health\Checks;
 use Butler\Health\Check;
 use Butler\Health\Result;
 use Illuminate\Support\Facades\Redis as RedisClient;
-use Illuminate\Support\Str;
 
 class Redis extends Check
 {
@@ -23,12 +22,7 @@ class Redis extends Check
         }
 
         try {
-            RedisClient::set(
-                $key = 'butler-health-check',
-                $string = Str::random()
-            );
-
-            if (RedisClient::get($key) === $string) {
+            if (RedisClient::ping()) {
                 return Result::ok("Connected to redis on {$host}.");
             }
         } catch (\Exception) {

--- a/tests/Checks/RedisCheckTest.php
+++ b/tests/Checks/RedisCheckTest.php
@@ -5,6 +5,7 @@ namespace Butler\Tests\Health;
 use Butler\Health\Checks\Redis;
 use Butler\Health\Result;
 use Butler\Health\Tests\AbstractTestCase;
+use Illuminate\Support\Facades\Redis as RedisClient;
 
 class RedisCheckTest extends AbstractTestCase
 {
@@ -33,6 +34,23 @@ class RedisCheckTest extends AbstractTestCase
 
         $this->assertEquals('Redis host undefined.', $result->message);
         $this->assertEquals(Result::UNKNOWN, $result->state);
+        $this->assertNull($result->value());
+    }
+
+    public function test_ok()
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped();
+        }
+
+        config(['database.redis.default.host' => 'localhost']);
+
+        RedisClient::shouldReceive('ping')->once()->andReturnTrue();
+
+        $result = (new Redis())->run();
+
+        $this->assertEquals('Connected to redis on localhost.', $result->message);
+        $this->assertEquals(Result::OK, $result->state);
         $this->assertNull($result->value());
     }
 }


### PR DESCRIPTION
The redis check failed randomly (probably) because the new cached value was stored after the value was retrieved.