### PR TITLE
Reconnect to the database if a PDO connection is missing in Database check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Reconnect to the database if a PDO connection is missing in Database check.
 
 ## [0.2.0] - 2022-02-14
 ### Changed

--- a/src/Checks/Database.php
+++ b/src/Checks/Database.php
@@ -25,7 +25,14 @@ class Database extends Check
             ++$checkedDatabases;
 
             try {
-                if (DB::connection($connection)->getPdo()) {
+                /** @var \Illuminate\Database\Connection */
+                $connection = DB::connection($connection);
+
+                if (is_null($connection->getPdo())) {
+                    $connection->reconnect();
+                }
+
+                if ($connection->getPdo()) {
                     ++$connectedDatabases;
                 }
             } catch (\Exception) {

--- a/tests/Checks/DatabaseCheckTest.php
+++ b/tests/Checks/DatabaseCheckTest.php
@@ -5,6 +5,7 @@ namespace Butler\Tests\Health;
 use Butler\Health\Checks\Database;
 use Butler\Health\Result;
 use Butler\Health\Tests\AbstractTestCase;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseCheckTest extends AbstractTestCase
 {
@@ -55,6 +56,26 @@ class DatabaseCheckTest extends AbstractTestCase
         $result = (new Database())->run();
 
         $this->assertEquals('Connected to all 2 databases.', $result->message);
+        $this->assertEquals(Result::OK, $result->state);
+        $this->assertEquals(1, $result->value());
+    }
+
+    public function test_ok_when_connection_was_disconnected()
+    {
+        config([
+            'database.connections' => [
+                'testing' => [
+                    'driver' => 'sqlite',
+                    'database' => ':memory:',
+                ]
+            ]
+        ]);
+
+        DB::connection('testing')->disconnect();
+
+        $result = (new Database())->run();
+
+        $this->assertEquals('Connected to the database.', $result->message);
         $this->assertEquals(Result::OK, $result->state);
         $this->assertEquals(1, $result->value());
     }


### PR DESCRIPTION
Needed in a octane environment using the "DisconnectFromDatabases".